### PR TITLE
Fix installation for x86_64 Linux

### DIFF
--- a/bin/get_haskell_stack
+++ b/bin/get_haskell_stack
@@ -141,7 +141,7 @@ do_ubuntu_install() {
   if is_64_bit ; then
     install_dependencies
     print_bindist_notice
-    install_64bit_static_binary
+    install_64bit_standard_binary
   else
     install_dependencies
     print_bindist_notice
@@ -167,7 +167,7 @@ do_debian_install() {
   elif is_64_bit ; then
     install_dependencies
     print_bindist_notice
-    install_64bit_static_binary
+    install_64bit_standard_binary
   else
     install_dependencies
     print_bindist_notice
@@ -187,7 +187,7 @@ do_fedora_install() {
   if is_64_bit ; then
     install_dependencies "$1"
     print_bindist_notice
-    install_64bit_static_binary
+    install_64bit_standard_binary
   else
     install_dependencies "$1"
     print_bindist_notice
@@ -207,7 +207,7 @@ do_centos_install() {
   if is_64_bit ; then
     install_dependencies
     print_bindist_notice
-    install_64bit_static_binary
+    install_64bit_standard_binary
   else
     install_dependencies
     case "$1" in
@@ -256,7 +256,7 @@ do_alpine_install() {
   }
   install_dependencies
   if is_64_bit ; then
-    install_64bit_static_binary
+    install_64bit_standard_binary
   else
     die "Sorry, there is currently no 32-bit Alpine Linux binary available."
   fi
@@ -272,7 +272,7 @@ do_sloppy_install() {
   if is_arm ; then
       install_arm_binary
   elif is_64_bit ; then
-      install_64bit_static_binary
+      install_64bit_standard_binary
   else
       install_32bit_standard_binary
   fi
@@ -467,8 +467,13 @@ install_32bit_standard_binary() {
   install_from_bindist "linux-i386"
 }
 
+# missing from stackage.org at the moment
 install_64bit_static_binary() {
   install_from_bindist "linux-x86_64-static"
+}
+
+install_64bit_standard_binary() {
+  install_from_bindist "linux-x86_64"
 }
 
 install_32bit_gmp4_linked_binary() {


### PR DESCRIPTION
 * There was failed download attempt of the installation tar ball from
   https://www.stackage.org/stack/linux-x86_64-static. From
   https://www.stackage.org/stack/ the link to this version was seen,
   but it gave 404. The link to  https://www.stackage.org/stack/linux-x86_64
   worked though, so changed to use this instead.
   Note that for 32-bit Linux, "linux-x86" version only was listed available
   and also used by asdf-haskell.
* This pull request proposes a fix for Issue #6 