### PR TITLE
Force cURL to accept GZIP.

### DIFF
--- a/bin/get_haskell_stack
+++ b/bin/get_haskell_stack
@@ -422,7 +422,7 @@ See http://docs.haskellstack.org/en/stable/install_and_upgrade/"
 # using 'curl' or 'wget'.
 dl_to_stdout() {
   if has_curl ; then
-    curl ${QUIET:+-sS} -L "$@"
+    curl --compressed ${QUIET:+-sS} -L "$@"
   elif has_wget ; then
     wget ${QUIET:+-q} -O- "$@"
   else

--- a/bin/install
+++ b/bin/install
@@ -3,7 +3,7 @@
 ghc_version () {
     local version=$1
     local url="https://downloads.haskell.org/~ghc/${version}/"
-    curl -s "$url" | grep -oE 'ghc-[^-]+' | head -n 1 | sed -e 's/ghc-//g'
+    curl --compressed -s "$url" | grep -oE 'ghc-[^-]+' | head -n 1 | sed -e 's/ghc-//g'
 }
 
 ghc_install() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -9,7 +9,7 @@ function sort_versions() {
 }
 
 function ghc_versions () {
-  curl -s "$ghc_releases" | grep -oE '[0-9]+\.[^/]+' | uniq
+  curl --compressed -s "$ghc_releases" | grep -oE '[0-9]+\.[^/]+' | uniq
 }
 
 versions="$(ghc_versions | sort_versions)"


### PR DESCRIPTION
I did a little experimenting with the issue described in #9, and came up with a slightly different diagnosis. On my machine, at any rate, cURL wasn't choking on an IPv6 DNS record but on the GZIPped response. Adding the `--compressed` flag seems to fix the problem. (See below.)

![ScreenFlow](https://user-images.githubusercontent.com/2207980/57149931-d8ba7400-6d9a-11e9-8fa7-ffabef0e0276.gif)
